### PR TITLE
`import torch` (was missing)

### DIFF
--- a/_notebooks/2020-12-02-dataloaders-samplers-collate.ipynb
+++ b/_notebooks/2020-12-02-dataloaders-samplers-collate.ipynb
@@ -1099,6 +1099,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def chunk(indices, chunk_size):\n",
     "    return torch.split(torch.tensor(indices), chunk_size)\n",
     "\n",


### PR DESCRIPTION
torch was not imported so `chunk` did not work.